### PR TITLE
Windows CI, fix warning and lint.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-name: ci
+name: Continuous Integration
 
 on:
-  pull_request: {types: [synchronize]}
+  pull_request:
   push:
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest]  # TODO windows-latest
+        os: [ubuntu-latest, windows-latest]
         python: [3.6, 3.7, 3.8, 3.9]
     runs-on: "${{matrix.os}}"
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Support for Sphinx 3.x and 4.x ([#7](https://github.com/Robpol86/sphinx-disqus/pull/7))
+- Fixed docutils warning for `traverse()` ([#14](https://github.com/Robpol86/sphinx-disqus/pull/14))
 - Re-licensed from MIT to BSD 2-Clause.
 - Dropped Python 2.7 and <3.6 support.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ fail_under = 85
 branch = true
 
 [tool.pylint.FORMAT]
-disable = ["super-with-arguments"]
 good-names = ["i", "j", "k", "ex", "Run", "_", "x", "y", "z", "fd"]
 ignore = [".venv/*", "build/*", "dist/*"]
 max-args = 6

--- a/sphinx_disqus/disqus.py
+++ b/sphinx_disqus/disqus.py
@@ -35,7 +35,7 @@ class DisqusNode(nodes.General, nodes.Element):
         :param disqus_shortname: Required Disqus forum name identifying the website.
         :param disqus_identifier: Unique identifier for each page where Disqus is present.
         """
-        super(DisqusNode, self).__init__()
+        super().__init__()
         self.disqus_shortname = disqus_shortname
         self.disqus_identifier = disqus_identifier
 
@@ -80,10 +80,10 @@ class DisqusDirective(Directive):
         if "disqus_identifier" in self.options:
             return self.options["disqus_identifier"]
 
-        title_nodes = self.state.document.traverse(nodes.title)
-        if not title_nodes:
+        title_node = next(iter(self.state.document.traverse(nodes.title)), None)
+        if not title_node:
             raise DisqusError("No title nodes found in document, cannot derive disqus_identifier config value.")
-        return title_nodes[0].astext()
+        return title_node.astext()
 
     def run(self) -> List:
         """Executed by Sphinx.
@@ -122,6 +122,9 @@ def setup(app: Sphinx) -> Dict[str, str]:
     app.add_config_value("disqus_shortname", None, True)
     app.add_directive("disqus", DisqusDirective)
     app.add_node(DisqusNode, html=(DisqusNode.visit, DisqusNode.depart))
-    app.config.html_static_path.append(os.path.relpath(STATIC_DIR, app.confdir))
+    try:
+        app.config.html_static_path.append(os.path.relpath(STATIC_DIR, app.confdir))
+    except ValueError:
+        app.config.html_static_path.append(STATIC_DIR)
     app.connect("html-page-context", event_html_page_context)
     return dict(version=__version__)


### PR DESCRIPTION
Enabling Windows CI in GitHub Actions. Requires try/except block since
GH actions checks out code in D:\ while packages are installed in C:\.

Fixing docutils warning about `traverse()` changing to a generator soon.

Python 3 style `super()`.