### PR TITLE
Recent Sphinx fixes, latest disqus.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Support for Sphinx 3.x and 4.x ([#7](https://github.com/Robpol86/sphinx-disqus/pull/7))
-- Fixed docutils warning for `traverse()` ([#14](https://github.com/Robpol86/sphinx-disqus/pull/14))
-- Re-licensed from MIT to BSD 2-Clause.
-- Dropped Python 2.7 and <3.6 support.
+### Added
+
+- Support for `file://` ([#15](https://github.com/Robpol86/sphinx-disqus/pull/15))
+
+### Removed
+
+- Dropped Python 2.7 and <3.6 support
+
+### Fixed
+
+- Support for Sphinx 1.6+ ([#7](https://github.com/Robpol86/sphinx-disqus/pull/7))
+- Fixed new html_static_path append and timing ([#15](https://github.com/Robpol86/sphinx-disqus/pull/15))
+
+### Changed
+
+- Re-licensed from MIT to BSD 2-Clause
+- Renamed project from `sphinxcontrib-disqus` to `sphinx-disqus`
+- Updated disqus.js with their latest universal code
 
 ## [1.1.0] - 2016-08-04
 

--- a/sphinx_disqus/_static/disqus.js
+++ b/sphinx_disqus/_static/disqus.js
@@ -1,10 +1,21 @@
-var disqus_shortname;
-var disqus_identifier;
-(function() {{
-    var disqus_thread = $("#disqus_thread");
-    disqus_shortname = disqus_thread.data('disqus-shortname');
-    disqus_identifier = disqus_thread.data('disqus-identifier');
-    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-}})();
+var disqus_config; // Accessed by embed.js
+const SphinxDisqus = {
+    init: function () {
+        let disqus_thread = $("#disqus_thread"); // Disqus <div />
+        let disqus_shortname = disqus_thread.data('disqus-shortname');
+        let disqus_identifier = disqus_thread.data('disqus-identifier');
+
+        // Disqus universal code below: https://disqus.com/admin/install/platforms/universalcode/
+        disqus_config = function () {
+            this.page.identifier = disqus_identifier;
+        };
+        let d = document, s = d.createElement('script');
+        s.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+    },
+};
+
+$(document).ready(function () {
+    SphinxDisqus.init();
+});

--- a/sphinx_disqus/disqus.py
+++ b/sphinx_disqus/disqus.py
@@ -1,8 +1,8 @@
 """Sphinx extension that embeds Disqus comments in documents.
 
-https://sphinxcontrib-disqus.readthedocs.org
-https://github.com/Robpol86/sphinxcontrib-disqus
-https://pypi.python.org/pypi/sphinxcontrib-disqus
+https://sphinx-disqus.readthedocs.io
+https://github.com/Robpol86/sphinx-disqus
+https://pypi.org/project/sphinx-disqus
 """
 import os
 import re
@@ -122,9 +122,6 @@ def setup(app: Sphinx) -> Dict[str, str]:
     app.add_config_value("disqus_shortname", None, True)
     app.add_directive("disqus", DisqusDirective)
     app.add_node(DisqusNode, html=(DisqusNode.visit, DisqusNode.depart))
-    try:
-        app.config.html_static_path.append(os.path.relpath(STATIC_DIR, app.confdir))
-    except ValueError:
-        app.config.html_static_path.append(STATIC_DIR)
+    app.connect("builder-inited", lambda app_: app_.config.html_static_path.append(STATIC_DIR))
     app.connect("html-page-context", event_html_page_context)
     return dict(version=__version__)


### PR DESCRIPTION
Updated disqus.js with their latest universal code.

Recent Sphinx versions moved html_static_path insertion from the bottom
of HTML documents to the top, causing disqus.js to run before the
`<div />` has been loaded. Fixing this by using `$(document).ready()`.

Recent Sphinx versions also started ignoring prior
html_static_path.append() during `setup(app)` call. Fixed this by
appending during `builder-inited` event.