### PR TITLE
PyPI, distclean, >= dev deps

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,27 @@
+name: PyPI
+
+on:
+  release: {types: [published]}
+
+jobs:
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Install Python, uses: actions/setup-python@v2, with: {python-version: 3.9}, id: py}
+      - {name: Install Poetry, uses: abatilo/actions-poetry@v2.1.2}
+      - {name: Copy LICENSE to COPYING, run: cp --no-clobber --verbose LICENSE COPYING}  # For Python wheel.
+      - {name: Build package, run: make build}
+      - name: Publish Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+#      - name: Publish package to TestPyPI
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          user: __token__
+#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#          repository_url: https://test.pypi.org/legacy/

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,15 @@ itpdb: deps
 	poetry run pytest --pdb tests/integration_tests
 
 .PHONY: all
-all: _HELP = Run linters, unit tests, and integration tests
-all: lint test it docs
+all: _HELP = Run linters, unit tests, integration tests, and builds
+all: lint test it docs build
 
 ## Build
+
+.PHONY: build
+build: _HELP = Build Python package (sdist and wheel)
+build:
+	poetry build -n -vvv
 
 docs/_build/html/index.html: deps
 	poetry run sphinx-build -a -E -n -W docs $(@D)
@@ -66,8 +71,12 @@ docs: docs/_build/html/index.html
 
 clean: _HELP = Remove temporary files
 clean:
-	rm -rf *.egg-info/ *cache*/ .*cache*/ .coverage coverage.xml htmlcov/ .venv/ dist/ docs/_build requirements.txt
+	rm -rfv *.egg-info/ *cache*/ .*cache*/ .coverage coverage.xml htmlcov/ dist/ docs/_build requirements.txt
 	find . -name __pycache__ -type d -exec rm -r {} +
+
+distclean: _HELP = Remove temporary files including virtualenv
+distclean: clean
+	rm -rf .venv/
 
 define MAKEFILE_HELP_AWK
 BEGIN {

--- a/poetry.lock
+++ b/poetry.lock
@@ -755,7 +755,7 @@ docs = ["sphinx-notfound-page", "sphinx-panels", "sphinx-rtd-theme", "sphinx_cop
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "d6775ee7af55ea2fe8b9d3854d1bf32235392b061ecb515fbba425372243c01d"
+content-hash = "3c268c71f554f9da41a2db121647d0034135b067af88060a9d5da133035213e0"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "poetry.masonry.api"
 name = "sphinx-disqus"
 version = "1.1.0"
 description = "Embed Disqus comments in Sphinx documents/pages."
+readme = "README.md"
 authors = ["Robpol86 <robpol86@gmail.com>"]
 license = "BSD-2-Clause"
 classifiers = [
@@ -31,7 +32,6 @@ classifiers = [
 
 [tool.poetry.urls]
 documentation = "https://sphinx-disqus.readthedocs.io"
-homepage = "https://pypi.org/project/sphinx-disqus"
 repository = "https://github.com/Robpol86/sphinx-disqus"
 
 [tool.poetry.dependencies]
@@ -51,16 +51,18 @@ docs = ["sphinx-notfound-page", "sphinx-panels", "sphinx-rtd-theme", "sphinx_cop
 [tool.poetry.dev-dependencies]
 # Linters.
 black = "*"
-flake8 = "*"
-flake8-docstrings = "*"
-flake8-import-order = "*"
-pep8-naming = "*"
-pylint = "*"
+flake8 = ">=3.9.2"
+flake8-docstrings = ">=1.6.0"
+flake8-import-order = ">=0.18.1"
+pep8-naming = ">=0.11.1"
+pylint = ">=2.8.3"
 # Tests.
-coverage = {version = "*", extras = ["toml"]}
-pytest = "*"
-pytest-cov = "*"
-pytest-icdiff = "*"
+coverage = {version = ">=5.5", extras = ["toml"]}
+pytest = ">=6.2.4"
+pytest-cov = ">=2.12.1"
+pytest-icdiff = ">=0.5"
+# Project.
+sphinx = ">=3.0"
 
 [tool.black]
 line-length = 125


### PR DESCRIPTION
Adding PyPI publish gh workflow.

Adding distclean Makefile target.

Populating PyPI long_description with `readme =` in pyproject.

Removing `homepage` link since it doesn't make sense once this is
published to PyPI.

Pinning dev dependency versions to >= current latest versions.