### PR TITLE
Build in CI, split deploy, save artifacts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - {name: Run tests, run: make test}
       - {name: Run integration tests, run: make it}
       - {name: Build docs, run: make docs}
+      - {name: Build package, run: make build}
       - name: Upload coverage
         uses: codecov/codecov-action@v1.5.0
         with: {name: "coverage-${{runner.os}}-py${{steps.py.outputs.python-version}}"}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
 
-  publish:
-    name: Publish to PyPI
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - {name: Check out repository code, uses: actions/checkout@v2}
@@ -14,14 +14,21 @@ jobs:
       - {name: Install Poetry, uses: abatilo/actions-poetry@v2.1.4}
       - {name: Copy LICENSE to COPYING, run: cp --no-clobber --verbose LICENSE COPYING}  # For Python wheel.
       - {name: Build package, run: make build}
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with: {name: dist, path: dist/, if-no-files-found: error}
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Fetch artifacts, uses: actions/download-artifact@v2, with: {name: dist, path: dist}}
       - name: Publish Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-#      - name: Publish package to TestPyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          user: __token__
-#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository_url: https://test.pypi.org/legacy/
+      - name: Upload HTML Archive to Release
+        uses: svenstaro/upload-release-action@v2
+        with: {file: dist/*, file_glob: true, repo_token: "${{ secrets.GITHUB_TOKEN }}", tag: "${{ github.ref }}"}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,12 +23,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - {name: Fetch artifacts, uses: actions/download-artifact@v2, with: {name: dist, path: dist}}
-      - name: Publish Python distribution to PyPI
+      - {name: Fetch packages, uses: actions/download-artifact@v2, with: {name: dist, path: dist}}
+      - name: Publish packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Upload HTML Archive to Release
+      - name: Upload packages to Release
         uses: svenstaro/upload-release-action@v2
         with: {file: dist/*, file_glob: true, repo_token: "${{ secrets.GITHUB_TOKEN }}", tag: "${{ github.ref }}"}


### PR DESCRIPTION
Build package in CI to catch bugs before making a release.

Split deploy workflow into two jobs: build and deploy. Also push
wheel/package to GitHub release.