### PR TITLE
Adding content: write permission

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -64,6 +64,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/sphinx-disqus
     permissions:
+      contents: write
       id-token: write
     steps:
       - name: Download Build Artifact


### PR DESCRIPTION
Got this error when upload-release-action tried to add artifacs to an existing release:

```
Error: Resource not accessible by integration - https://docs.github.com/rest
```

Fixing as per
https://github.com/svenstaro/upload-release-action/tree/v2/?tab=readme-ov-file#permissions