### PR TITLE
Copy to release/

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -76,11 +76,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: docs
-          path: dist
+          path: release
+      - name: Copy
+        run: cp -v dist/* release/
       - name: Upload to Release
         uses: svenstaro/upload-release-action@v2
         with:
-          file: dist/*
+          file: release/*
           file_glob: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}


### PR DESCRIPTION
pypa/gh-action-pypi-publish is too greedy and thinks docs.tar.gz is another python package. Unfortunately svenstaro/upload-release-action doesn't support multiple paths besides globbing.

Keeping `dist/` only for PyPI and staging release files in `release/` to mitigate this problem.